### PR TITLE
Add region filter to racecards

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,27 +187,35 @@ To scrape a particular course or region, use the -c or -r flags with the course 
 
 You can scrape racecards using racecards.py which saves a file containing a json object of racecard information.
 
-There are only two parameter options, --day N and --days N where N is a number 1-2.
+There are only three parameter options, --day N, --days N where N is a number 1-2, and --region N where N is a region (gb, ire, etc).
 
 ### Examples
 
-Scrape todays racecards.
+Scrape today's racecards.
 
 ```
 ./racecards.py --day 1
 ```
 
-Scrape tomorrows racecards.
+Scrape tomorrow's racecards.
 
 ```
 ./racecards.py --day 2
 ```
 
-Scrape todays and tomorrows racecards.
+Scrape today's and tomorrow's racecards.
 
 ```
 ./racecards.py --days 2
 ```
+
+Scrape today's and tomorrow's racecards by region.
+
+```
+./racecards.py --days 2 --region gb
+```
+
+You can also drastically reduce the size of the racecard pull by using the ```racecard_fields.toml``` file. Copy either the ```racecard_fields_minimal.toml``` or ```racecard_fields_standard.toml``` to replace ```racecard_fields.toml```. The script uses whatever is in the ```racecard_fields.toml``` file.
 
 You can see the structure of the json and some of the race information below.
 

--- a/scripts/racecards.py
+++ b/scripts/racecards.py
@@ -8,9 +8,11 @@ import sys
 
 from collections import defaultdict
 from lxml import etree, html
+from pathlib import Path
 from tqdm import tqdm
 from typing import Any
 from orjson import dumps
+import tomli
 
 from utils.cleaning import normalize_name
 from utils.course import valid_meeting
@@ -19,7 +21,7 @@ from utils.going import get_surface
 from utils.lxml_funcs import find
 from utils.network import get_request
 from utils.profiles import get_profiles
-from utils.region import get_region
+from utils.region import get_region, valid_region
 from utils.stats import Stats
 
 from models.racecard import Racecard, Runner
@@ -40,6 +42,55 @@ RACE_TYPE = {
 type Racecards = defaultdict[str, defaultdict[str, defaultdict[str, dict[str, Any]]]]
 
 
+def load_field_config() -> dict[str, Any]:
+    """Load field configuration from settings/racecard_fields.toml"""
+    config_path = Path('../settings/racecard_fields.toml')
+    
+    if not config_path.exists():
+        # Return default config (everything enabled)
+        return {
+            'data_collection': {
+                'fetch_profiles': True,
+                'fetch_stats': True,
+                'fetch_quotes': True,
+                'fetch_medical': True,
+                'fetch_history': True,
+            },
+            'runner_fields': {},  # Empty means all fields
+        }
+    
+    with open(config_path, 'rb') as f:
+        config = tomli.load(f)
+    
+    # Handle presets
+    if 'preset' in config and 'mode' in config['preset']:
+        mode = config['preset']['mode']
+        if mode == 'minimal':
+            config['data_collection'] = {
+                'fetch_profiles': False,
+                'fetch_stats': False,
+                'fetch_quotes': False,
+                'fetch_medical': False,
+                'fetch_history': False,
+            }
+            config['runner_fields'] = {
+                'name': True, 'horse_id': True, 'number': True, 'draw': True,
+                'age': True, 'jockey': True, 'jockey_id': True,
+                'trainer': True, 'trainer_id': True, 'lbs': True,
+                'form': True, 'rpr': True, 'ofr': True,
+            }
+        elif mode == 'standard':
+            config['data_collection'] = {
+                'fetch_profiles': True,
+                'fetch_stats': True,
+                'fetch_quotes': False,
+                'fetch_medical': False,
+                'fetch_history': False,
+            }
+    
+    return config
+
+
 def validate_days_range(value: str) -> int:
     try:
         days = int(value)
@@ -52,8 +103,9 @@ def validate_days_range(value: str) -> int:
         raise argparse.ArgumentTypeError(f"Invalid value: '{value}'. Expected an integer.")
 
 
-def get_race_urls(dates: list[str]) -> dict[str, list[tuple[str, str]]]:
+def get_race_urls(dates: list[str], region: str | None = None) -> dict[str, list[tuple[str, str]]]:
     race_urls: defaultdict[str, list[tuple[str, str]]] = defaultdict(list)
+    url_base = 'https://www.racingpost.com'
 
     for date in dates:
         url = f'https://www.racingpost.com/racecards/{date}'
@@ -65,7 +117,37 @@ def get_race_urls(dates: list[str]) -> dict[str, list[tuple[str, str]]]:
             course = meeting.xpath(".//span[contains(@class, 'RC-accordion__courseName')]")[0]
             if valid_meeting(course.text_content().strip().lower()):
                 for race in meeting.xpath(".//a[@class='RC-meetingItem__link js-navigate-url']"):
-                    race_urls[date].append((race.attrib['data-race-id'], race.attrib['href']))
+                    # If a region filter is provided, do a lightweight check against the
+                    # runners JSON to determine the course region and skip non-matching races.
+                    race_id = race.attrib['data-race-id']
+                    href = race.attrib['href']
+
+                    if region:
+                        try:
+                            status_runners, resp_runners = get_request(
+                                f'{url_base}/profile/horse/data/cardrunners/{race_id}.json'
+                            )
+                        except Exception:
+                            # On failure, skip this race
+                            continue
+
+                        if status_runners != 200:
+                            continue
+
+                        try:
+                            runners = resp_runners.json().get('runners', {})
+                            first = next(iter(runners.values()))
+                            course_uid = first.get('courseUid')
+                        except Exception:
+                            continue
+
+                        if not course_uid:
+                            continue
+
+                        if get_region(str(course_uid)) != region.upper():
+                            continue
+
+                    race_urls[date].append((race_id, href))
 
     return dict(race_urls)
 
@@ -114,97 +196,160 @@ def parse_prize(doc: html.HtmlElement) -> str | None:
 
 
 def parse_runners(
-    stats: Stats,
+    stats: Stats | None,
     runners_json: list[dict[str, Any]],
     profiles: dict[str, dict[str, Any]],
+    config: dict[str, Any],
 ) -> list[Runner]:
     runners: list[Runner] = []
+    runner_fields = config.get('runner_fields', {})
+    data_opts = config.get('data_collection', {})
+    
+    # If runner_fields is empty, include all fields
+    include_all = not runner_fields
 
     for runner_json in runners_json:
-        try:
-            profile = profiles[runner_json['horseUid']]
-        except KeyError:
-            print(f'Failed to find profile: {runner_json["horseUid"]} - {runner_json["horseName"]}')
-            print(dumps(runner_json).decode('utf-8'))
-            sys.exit(1)
+        profile = None
+        if data_opts.get('fetch_profiles', True):
+            try:
+                profile = profiles[runner_json['horseUid']]
+            except KeyError:
+                print(f'Failed to find profile: {runner_json["horseUid"]} - {runner_json["horseName"]}')
+                print(dumps(runner_json).decode('utf-8'))
+                sys.exit(1)
 
         runner = Runner()
         runners.append(runner)
 
-        runner.age = runner_json['horseAge']
-        runner.breeder = normalize_name(runner_json['breederName'])
-        runner.breeder_id = runner_json['breederUid']
-        runner.claim = runner_json['weightAllowanceLbs']
-        runner.colour = runner_json['horseColourCode']
-        runner.comment = runner_json['diomed']
-        runner.dam = normalize_name(runner_json['damName'])
-        runner.dam_id = runner_json['damId']
-        runner.dam_region = runner_json['damCountry']
-        runner.damsire = normalize_name(runner_json['damsireName'])
-        runner.damsire_id = runner_json['damsireId']
-        runner.damsire_region = runner_json['damsireCountry']
-        runner.dob = runner_json['horseDateOfBirth'].split('T')[0]
-        runner.draw = runner_json['draw'] if runner_json['draw'] else None
-        runner.form = (
-            ''.join(f['formFigure'] for f in runner_json['figuresCalculated'])[::-1]
-            if runner_json['figuresCalculated']
-            else ''
-        )
-        runner.gelding_first_time = runner_json['geldingFirstTime']
-        runner.headgear = runner_json['rpHorseHeadGearCode']
-        runner.headgear_first = runner_json['firstTime']
-        runner.horse_id = runner_json['horseUid']
-        runner.jockey = normalize_name(runner_json['jockeyName'])
-        runner.jockey_allowance = runner_json['weightAllowanceLbs']
-        runner.jockey_id = runner_json['jockeyUid']
-        runner.last_run = runner_json['daysSinceLastRun']
-        runner.lbs = runner_json['weightCarriedLbs']
-        runner.name = normalize_name(runner_json['horseName'])
-        runner.non_runner = runner_json['nonRunner']
-        runner.number = runner_json['startNumber']
-        runner.ofr = runner_json['officialRatingToday'] if runner_json['officialRatingToday'] else None
-        runner.owner = normalize_name(runner_json['ownerName'])
-        runner.owner_id = runner_json['ownerUid']
-        runner.profile = profile['profile']
-        runner.region = runner_json['countryOriginCode']
-        runner.reserve = runner_json['irishReserve']
-        runner.rpr = runner_json['rpPostmark'] if runner_json['rpPostmark'] else None
-        runner.sex = profile['horseSex']
-        runner.sex_code = runner_json['horseSexCode']
-        runner.silk_path = runner_json['silkImagePath']
-        runner.silk_url = f'https://www.rp-assets.com/svg/{runner.silk_path}.svg'
-        runner.sire = normalize_name(runner_json['sireName'])
-        runner.sire_id = runner_json['sireId']
-        runner.sire_region = runner_json['sireCountry']
-        runner.spotlight = runner_json['spotlight']
-        runner.trainer = normalize_name(runner_json['trainerStylename'])
-        runner.trainer_14_days = profile['trainerLast14Days']
-        runner.trainer_id = runner_json['trainerId']
-        runner.trainer_location = profile['trainerLocation']
-        runner.trainer_rtf = runner_json['trainerRtf']
-        runner.ts = runner_json['rpTopspeed'] if runner_json['rpTopspeed'] else None
-        runner.wind_surgery_first = runner_json['windSurgeryFirstTime']
-        runner.wind_surgery_second = runner_json['windSurgerySecondTime']
+        # Helper to check if field should be included
+        def should_include(field: str) -> bool:
+            return include_all or runner_fields.get(field, False)
 
-        horse_stats = (
-            stats.horses[str(runner.horse_id)].to_dict() if str(runner.horse_id) in stats.horses else {}
-        )
+        if should_include('age'):
+            runner.age = runner_json['horseAge']
+        if should_include('breeder'):
+            runner.breeder = normalize_name(runner_json['breederName'])
+        if should_include('breeder_id'):
+            runner.breeder_id = runner_json['breederUid']
+        if should_include('claim'):
+            runner.claim = runner_json['weightAllowanceLbs']
+        if should_include('colour'):
+            runner.colour = runner_json['horseColourCode']
+        if should_include('comment'):
+            runner.comment = runner_json['diomed']
+        if should_include('dam'):
+            runner.dam = normalize_name(runner_json['damName'])
+        if should_include('dam_id'):
+            runner.dam_id = runner_json['damId']
+        if should_include('dam_region'):
+            runner.dam_region = runner_json['damCountry']
+        if should_include('damsire'):
+            runner.damsire = normalize_name(runner_json['damsireName'])
+        if should_include('damsire_id'):
+            runner.damsire_id = runner_json['damsireId']
+        if should_include('damsire_region'):
+            runner.damsire_region = runner_json['damsireCountry']
+        if should_include('dob'):
+            runner.dob = runner_json['horseDateOfBirth'].split('T')[0]
+        if should_include('draw'):
+            runner.draw = runner_json['draw'] if runner_json['draw'] else None
+        if should_include('form'):
+            runner.form = (
+                ''.join(f['formFigure'] for f in runner_json['figuresCalculated'])[::-1]
+                if runner_json['figuresCalculated']
+                else ''
+            )
+        if should_include('gelding_first_time'):
+            runner.gelding_first_time = runner_json['geldingFirstTime']
+        if should_include('headgear'):
+            runner.headgear = runner_json['rpHorseHeadGearCode']
+        if should_include('headgear_first'):
+            runner.headgear_first = runner_json['firstTime']
+        if should_include('horse_id'):
+            runner.horse_id = runner_json['horseUid']
+        if should_include('jockey'):
+            runner.jockey = normalize_name(runner_json['jockeyName'])
+        if should_include('jockey_allowance'):
+            runner.jockey_allowance = runner_json['weightAllowanceLbs']
+        if should_include('jockey_id'):
+            runner.jockey_id = runner_json['jockeyUid']
+        if should_include('last_run'):
+            runner.last_run = runner_json['daysSinceLastRun']
+        if should_include('lbs'):
+            runner.lbs = runner_json['weightCarriedLbs']
+        if should_include('name'):
+            runner.name = normalize_name(runner_json['horseName'])
+        if should_include('non_runner'):
+            runner.non_runner = runner_json['nonRunner']
+        if should_include('number'):
+            runner.number = runner_json['startNumber']
+        if should_include('ofr'):
+            runner.ofr = runner_json['officialRatingToday'] if runner_json['officialRatingToday'] else None
+        if should_include('owner'):
+            runner.owner = normalize_name(runner_json['ownerName'])
+        if should_include('owner_id'):
+            runner.owner_id = runner_json['ownerUid']
+        if should_include('profile') and profile:
+            runner.profile = profile['profile']
+        if should_include('region'):
+            runner.region = runner_json['countryOriginCode']
+        if should_include('reserve'):
+            runner.reserve = runner_json['irishReserve']
+        if should_include('rpr'):
+            runner.rpr = runner_json['rpPostmark'] if runner_json['rpPostmark'] else None
+        if should_include('sex') and profile:
+            runner.sex = profile['horseSex']
+        if should_include('sex_code'):
+            runner.sex_code = runner_json['horseSexCode']
+        if should_include('silk_path'):
+            runner.silk_path = runner_json['silkImagePath']
+        if should_include('silk_url'):
+            runner.silk_url = f'https://www.rp-assets.com/svg/{runner_json["silkImagePath"]}.svg'
+        if should_include('sire'):
+            runner.sire = normalize_name(runner_json['sireName'])
+        if should_include('sire_id'):
+            runner.sire_id = runner_json['sireId']
+        if should_include('sire_region'):
+            runner.sire_region = runner_json['sireCountry']
+        if should_include('spotlight'):
+            runner.spotlight = runner_json['spotlight']
+        if should_include('trainer'):
+            runner.trainer = normalize_name(runner_json['trainerStylename'])
+        if should_include('trainer_14_days') and profile:
+            runner.trainer_14_days = profile['trainerLast14Days']
+        if should_include('trainer_id'):
+            runner.trainer_id = runner_json['trainerId']
+        if should_include('trainer_location') and profile:
+            runner.trainer_location = profile['trainerLocation']
+        if should_include('trainer_rtf'):
+            runner.trainer_rtf = runner_json['trainerRtf']
+        if should_include('ts'):
+            runner.ts = runner_json['rpTopspeed'] if runner_json['rpTopspeed'] else None
+        if should_include('wind_surgery_first'):
+            runner.wind_surgery_first = runner_json['windSurgeryFirstTime']
+        if should_include('wind_surgery_second'):
+            runner.wind_surgery_second = runner_json['windSurgerySecondTime']
 
-        jockey_stats = (
-            stats.jockeys[str(runner.jockey_id)] if str(runner.jockey_id) in stats.jockeys else {}
-        )
+        if should_include('stats') and stats:
+            horse_stats = (
+                stats.horses[str(runner.horse_id)].to_dict() if str(runner.horse_id) in stats.horses else {}
+            )
 
-        trainer_stats = (
-            stats.trainers[str(runner.trainer_id)] if str(runner.trainer_id) in stats.trainers else {}
-        )
+            jockey_stats = (
+                stats.jockeys[str(runner.jockey_id)] if str(runner.jockey_id) in stats.jockeys else {}
+            )
 
-        runner.stats = {
-            'horse': horse_stats,
-            'jockey': jockey_stats,
-            'trainer': trainer_stats,
-        }
+            trainer_stats = (
+                stats.trainers[str(runner.trainer_id)] if str(runner.trainer_id) in stats.trainers else {}
+            )
 
-        if profile['previousTrainers']:
+            runner.stats = {
+                'horse': horse_stats,
+                'jockey': jockey_stats,
+                'trainer': trainer_stats,
+            }
+
+        if should_include('prev_trainers') and data_opts.get('fetch_history', True) and profile and profile.get('previousTrainers'):
             runner.prev_trainers = [
                 {
                     'trainer': normalize_name(trainer['trainerStyleName']),
@@ -214,7 +359,7 @@ def parse_runners(
                 for trainer in profile['previousTrainers']
             ]
 
-        if profile['previousOwners']:
+        if should_include('prev_owners') and data_opts.get('fetch_history', True) and profile and profile.get('previousOwners'):
             runner.prev_owners = [
                 {
                     'owner': normalize_name(owner['ownerStyleName']),
@@ -224,13 +369,13 @@ def parse_runners(
                 for owner in profile['previousOwners']
             ]
 
-        if profile['medical']:
+        if should_include('medical') and data_opts.get('fetch_medical', True) and profile and profile.get('medical'):
             runner.medical = [
                 {'date': med['medicalDate'].split('T')[0], 'type': med['medicalType']}
                 for med in profile['medical']
             ]
 
-        if profile['quotes']:
+        if should_include('quotes') and data_opts.get('fetch_quotes', True) and profile and profile.get('quotes'):
             runner.quotes = [
                 {
                     'date': q['raceDate'].split('T')[0],
@@ -247,7 +392,7 @@ def parse_runners(
                 for q in profile['quotes']
             ]
 
-        if profile['stable_quotes']:
+        if should_include('stable_tour') and data_opts.get('fetch_quotes', True) and profile and profile.get('stable_quotes'):
             runner.stable_tour = [
                 {'horse': normalize_name(q['horseName']), 'horse_id': q['horseUid'], 'quote': q['notes']}
                 for q in profile['stable_quotes']
@@ -256,8 +401,12 @@ def parse_runners(
     return runners
 
 
-def scrape_racecards(race_urls: dict[str, list[tuple[str, str]]], date: str) -> Racecards:
+def scrape_racecards(race_urls: dict[str, list[tuple[str, str]]], date: str, config: dict[str, Any]) -> Racecards:
     races: Racecards = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    
+    data_opts = config.get('data_collection', {})
+    fetch_profiles = data_opts.get('fetch_profiles', True)
+    fetch_stats = data_opts.get('fetch_stats', True)
 
     for race_id, href in tqdm(
         race_urls[date],
@@ -299,10 +448,11 @@ def scrape_racecards(race_urls: dict[str, list[tuple[str, str]]], date: str) -> 
             print(f'url: {url_runners}')
             continue
 
-        profile_hrefs = doc.xpath("//a[@data-test-selector='RC-cardPage-runnerName']/@href")
-        profile_urls = [url_base + a.split('#')[0] + '/form' for a in profile_hrefs]
-
-        profiles = get_profiles(profile_urls)
+        profiles = {}
+        if fetch_profiles:
+            profile_hrefs = doc.xpath("//a[@data-test-selector='RC-cardPage-runnerName']/@href")
+            profile_urls = [url_base + a.split('#')[0] + '/form' for a in profile_hrefs]
+            profiles = get_profiles(profile_urls)
 
         race: Racecard = Racecard()
 
@@ -349,9 +499,9 @@ def scrape_racecards(race_urls: dict[str, list[tuple[str, str]]], date: str) -> 
         race.going = parse_going(doc)
         race.surface = get_surface(race.going)
 
-        stats = Stats(doc_accordion)
+        stats = Stats(doc_accordion) if fetch_stats else None
 
-        race.runners = parse_runners(stats, runners, profiles)
+        race.runners = parse_runners(stats, runners, profiles, config)
 
         races[race.region][race.course][race.off_time] = race.to_dict()
 
@@ -379,6 +529,13 @@ def main() -> None:
         metavar='N',
     )
 
+    _ = parser.add_argument(
+        '--region',
+        type=str,
+        help="Region code to filter by (e.g., 'gb', 'ire').",
+        metavar='CODE',
+    )
+
     args = parser.parse_args()
 
     dates: list[str] = [
@@ -397,10 +554,20 @@ def main() -> None:
     if not os.path.exists('../racecards'):
         os.makedirs('../racecards')
 
-    race_urls = get_race_urls(dates)
+    # Validate and pass optional region filter
+    region: str | None = None
+    if hasattr(args, 'region') and args.region:
+        region = args.region.lower()
+        if not valid_region(region):
+            print(f'Invalid region: {args.region}')
+            sys.exit(1)
+
+    race_urls = get_race_urls(dates, region)
+    
+    config = load_field_config()
 
     for date in race_urls:
-        racecards = scrape_racecards(race_urls, date)
+        racecards = scrape_racecards(race_urls, date, config)
 
         with open(f'../racecards/{date}.json', 'w', encoding='utf-8') as f:
             _ = f.write(dumps(racecards).decode('utf-8'))

--- a/settings/racecard_fields.toml
+++ b/settings/racecard_fields.toml
@@ -1,0 +1,37 @@
+# MINIMAL PRESET - Only essential race information
+# Fastest scraping, smallest file sizes
+# Skips: profiles, stats, quotes, medical, history, breeding details
+
+[preset]
+mode = "minimal"
+
+[data_collection]
+fetch_profiles = false
+fetch_stats = false
+fetch_quotes = false
+fetch_medical = false
+fetch_history = false
+
+[runner_fields]
+# Core identification
+name = true
+horse_id = true
+number = true
+draw = true
+
+# Basic info
+age = true
+jockey = true
+jockey_id = true
+trainer = true
+trainer_id = true
+
+# Performance
+lbs = true
+form = true
+rpr = true
+ofr = true
+ts = true
+
+# Status
+non_runner = true

--- a/settings/racecard_fields_minimal.toml
+++ b/settings/racecard_fields_minimal.toml
@@ -1,0 +1,37 @@
+# MINIMAL PRESET - Only essential race information
+# Fastest scraping, smallest file sizes
+# Skips: profiles, stats, quotes, medical, history, breeding details
+
+[preset]
+mode = "minimal"
+
+[data_collection]
+fetch_profiles = false
+fetch_stats = false
+fetch_quotes = false
+fetch_medical = false
+fetch_history = false
+
+[runner_fields]
+# Core identification
+name = true
+horse_id = true
+number = true
+draw = true
+
+# Basic info
+age = true
+jockey = true
+jockey_id = true
+trainer = true
+trainer_id = true
+
+# Performance
+lbs = true
+form = true
+rpr = true
+ofr = true
+ts = true
+
+# Status
+non_runner = true

--- a/settings/racecard_fields_standard.toml
+++ b/settings/racecard_fields_standard.toml
@@ -1,0 +1,70 @@
+# STANDARD PRESET - Good balance of data and performance
+# Includes profiles and stats but skips bulky historical data
+# Skips: quotes, medical history, previous owners/trainers
+
+[preset]
+mode = "standard"
+
+[data_collection]
+fetch_profiles = true
+fetch_stats = true
+fetch_quotes = false
+fetch_medical = false
+fetch_history = false
+
+[runner_fields]
+# All essential fields
+name = true
+horse_id = true
+number = true
+draw = true
+age = true
+sex = true
+colour = true
+region = true
+
+# Performance
+form = true
+rpr = true
+ts = true
+ofr = true
+last_run = true
+
+# Jockey/Trainer
+jockey = true
+jockey_id = true
+jockey_allowance = true
+trainer = true
+trainer_id = true
+trainer_location = true
+trainer_14_days = true
+trainer_rtf = true
+
+# Weight
+lbs = true
+claim = true
+
+# Equipment
+headgear = true
+headgear_first = true
+
+# Breeding (basic)
+sire = true
+sire_id = true
+dam = true
+dam_id = true
+
+# Ownership
+owner = true
+owner_id = true
+
+# Comments
+comment = true
+spotlight = true
+
+# Flags
+non_runner = true
+
+# Profile data
+profile = true
+stats = true


### PR DESCRIPTION
This pull request introduces a flexible field selection system for the racecard scraper, allowing users to control which data fields are included in the output via a TOML configuration file. It also adds support for filtering racecards by region and updates the documentation to reflect these new features. These changes help users reduce scrape time and output size, and make the tool more customizable for different use cases.

**Configuration and Field Selection Enhancements:**

* Added support for a `racecard_fields.toml` configuration file that allows users to specify which runner fields and data collections (profiles, stats, quotes, medical, history) are included in the output. Presets such as "minimal" and "standard" are supported for convenience. (`scripts/racecards.py`, `settings/racecard_fields.toml`, `settings/racecard_fields_minimal.toml`) [[1]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eR45-R93) [[2]](diffhunk://#diff-74dde23f9e1f1a70ccca9aef1f44c4d28b94cfbd8af7be2951176f11136d2402R1-R37)
* The `parse_runners` and `scrape_racecards` functions were refactored to conditionally include fields and fetch data based on the configuration, making the scraping process more efficient and customizable. (`scripts/racecards.py`) [[1]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eR224-R333) [[2]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL207-R352) [[3]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL217-R362) [[4]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL227-R378) [[5]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL250-R395) [[6]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL259-R410) [[7]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eR451-L304) [[8]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL352-R504)

**Region Filtering:**

* Added a `--region` command-line argument to filter racecards by region (e.g., 'gb', 'ire'), with validation to ensure only supported regions are accepted. The scraper now skips races outside the selected region. (`scripts/racecards.py`) [[1]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL22-R24) [[2]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL55-R108) [[3]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL68-R150) [[4]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eR532-R538) [[5]](diffhunk://#diff-1f264b6adefac79ce170c11915708dadf501e50d11b7ac3201ec6ab4cf07fc2eL400-R570)

**Documentation Updates:**

* Updated `README.md` to document the new `--region` argument and the use of the `racecard_fields.toml` file, including instructions for using presets and reducing output size. (`README.md`)

**Dependency and Import Updates:**

* Added imports for TOML parsing (`tomli`) and `Path` to support configuration file loading. (`scripts/racecards.py`)

These changes make the scraper more user-friendly and efficient, especially for users who only need a subset of racecard data or want to target specific regions.